### PR TITLE
Add basic setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Biggest differences when compared to Event Sourcery:
 - A separate streams table to manage stream versions isn't used.
 - Custom event class modelling improvements - see RecordedEvent, EventData and Event.
 
+## Development
+
+### Setup
+
+```
+./script/setup.sh
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+createdb eventory_test
+psql eventory_test < schema.sql
+
+bundle install


### PR DESCRIPTION
No error handling but I think keeping it simple is ok for now.

The errors are pretty clear as is:

```
$ ./script/setup.sh
createdb: database creation failed: ERROR:  database "eventory_test" already exists
```