### PR TITLE
Ensure EventHandler.handled_event_classes returns the correct events

### DIFF
--- a/lib/eventory/event_handler.rb
+++ b/lib/eventory/event_handler.rb
@@ -11,11 +11,12 @@ module Eventory
 
     module ClassMethods
       def event_handlers
-        @event_handlers ||= Hash.new { |hash, key| hash[key] = [] }
+        @event_handlers ||= {}
       end
 
       def on(*event_classes, &block)
         event_classes.each do |event_class|
+          event_handlers[event_class] ||= []
           event_handlers[event_class] << block
         end
       end
@@ -35,7 +36,7 @@ module Eventory
 
     def handle_event(recorded_event)
       @current_event = recorded_event
-      self.class.event_handlers[recorded_event.event_type_class].each do |handler|
+      self.class.event_handlers.fetch(recorded_event.event_type_class, []).each do |handler|
         instance_exec(recorded_event, &handler)
       end
     ensure

--- a/spec/eventory/event_handler_spec.rb
+++ b/spec/eventory/event_handler_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe Eventory::EventHandler do
   end
 
   it 'returns handled event classes' do
-    expect(TestHandler.handled_event_classes).to eq([ItemAdded, ItemRemoved, ItemStarred])
+    expect(TestHandler.handled_event_classes).to eq([ItemAdded, ItemRemoved])
   end
 end


### PR DESCRIPTION
Because the @event_handlers Hash had a default value of [] if you accessed a value that didn't exist it would implicitly create an empty Array thus changing the keys in the Hash.

Consider the following:

    irb(main):001:0> @event_handlers ||= Hash.new { |hash, key| hash[key] = [] }
    => {}
    irb(main):002:0> @event_handlers['foo'] << 1
    => [1]
    irb(main):003:0> @event_handlers
    => {"foo"=>[1]}
    irb(main):004:0> @event_handlers['bar']
    => []
    irb(main):005:0> @event_handlers
    => {"foo"=>[1], "bar"=>[]}
    irb(main):006:0> @event_handlers.keys
    => ["foo", "bar"]