### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4']
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: eventory_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_USER: runner
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: psql --host=127.0.0.1 --port=5432 --dbname=eventory_test --file=schema.sql
+      - run: bundle exec rake --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4.2
-before_install: gem install bundler -v 1.16.0


### PR DESCRIPTION
Travis CI is dead. Let's use GitHub Actions instead.