### PR TITLE
Bump Bundler from 1.16.0 to 2.3.27

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
   database_cleaner
   eventory!
   pry
@@ -44,4 +43,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.0
+   2.3.27

--- a/eventory.gemspec
+++ b/eventory.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Resolves:
- https://github.com/envato/eventory/security/dependabot/3
- https://github.com/envato/eventory/security/dependabot/4
- https://github.com/envato/eventory/security/dependabot/5
- https://github.com/envato/eventory/security/dependabot/6